### PR TITLE
Implement dynamic base fee

### DIFF
--- a/go/enclave/components/batch_executor.go
+++ b/go/enclave/components/batch_executor.go
@@ -551,6 +551,7 @@ func (executor *batchExecutor) execResult(ec *BatchExecutionContext) (*ComputedB
 		return nil, fmt.Errorf("failed to commit trieDB. Cause: %w", err)
 	}
 	batch.Header.Root = rootHash
+	batch.Header.GasUsed = *ec.usedGas
 
 	batch.ResetHash()
 

--- a/go/enclave/nodetype/basefee.go
+++ b/go/enclave/nodetype/basefee.go
@@ -1,0 +1,51 @@
+package nodetype
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// calcNextBaseFee calculates the next base fee following the
+// EIP-1559 algorithm. It takes the previous base fee, gas used
+// in the previous batch and the gas limit of that batch.
+func calcNextBaseFee(parentBaseFee *big.Int, gasUsed, gasLimit uint64) *big.Int {
+	if parentBaseFee == nil {
+		return big.NewInt(params.InitialBaseFee)
+	}
+	// If gas limit is zero just return previous base fee.
+	if gasLimit == 0 {
+		return new(big.Int).Set(parentBaseFee)
+	}
+
+	target := gasLimit / params.ElasticityMultiplier
+	if target == 0 {
+		return new(big.Int).Set(parentBaseFee)
+	}
+
+	baseFee := new(big.Int).Set(parentBaseFee)
+	changeDenom := new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
+
+	if gasUsed == target {
+		return baseFee
+	} else if gasUsed > target {
+		delta := new(big.Int).Mul(baseFee, big.NewInt(int64(gasUsed-target)))
+		delta.Div(delta, new(big.Int).SetUint64(target))
+		delta.Div(delta, changeDenom)
+		if delta.Sign() == 0 {
+			delta.SetInt64(1)
+		}
+		return baseFee.Add(baseFee, delta)
+	}
+
+	delta := new(big.Int).Mul(baseFee, big.NewInt(int64(target-gasUsed)))
+	delta.Div(delta, new(big.Int).SetUint64(target))
+	delta.Div(delta, changeDenom)
+	if delta.Sign() == 0 {
+		delta.SetInt64(1)
+	}
+	if baseFee.Cmp(delta) <= 0 {
+		return big.NewInt(0)
+	}
+	return baseFee.Sub(baseFee, delta)
+}

--- a/go/enclave/nodetype/sequencer.go
+++ b/go/enclave/nodetype/sequencer.go
@@ -225,6 +225,11 @@ func (s *sequencer) produceBatch(
 	batchTime uint64,
 	failForEmptyBatch bool,
 ) (*components.ComputedBatch, error) {
+	parentHeader, err := s.storage.FetchBatchHeader(ctx, headBatch)
+	if err == nil {
+		s.settings.BaseFee = calcNextBaseFee(parentHeader.BaseFee, parentHeader.GasUsed, parentHeader.GasLimit)
+	}
+
 	cb, err := s.batchProducer.ComputeBatch(ctx,
 		&components.BatchExecutionContext{
 			BlockPtr:      l1Hash,
@@ -249,6 +254,7 @@ func (s *sequencer) produceBatch(
 	if err := s.StoreExecutedBatch(ctx, cb.Batch, cb.TxExecResults); err != nil {
 		return nil, fmt.Errorf("2. failed storing batch. Cause: %w", err)
 	}
+	s.settings.BaseFee = calcNextBaseFee(cb.Batch.Header.BaseFee, cb.Batch.Header.GasUsed, cb.Batch.Header.GasLimit)
 
 	s.logger.Info("Produced new batch", log.BatchHashKey, cb.Batch.Hash(),
 		"height", cb.Batch.Number(), "numTxs", len(cb.Batch.Transactions), log.BatchSeqNoKey, cb.Batch.SeqNo(), "parent", cb.Batch.Header.ParentHash)


### PR DESCRIPTION
## Summary
- add a calcNextBaseFee helper based on EIP‑1559
- compute gas used and store it in the batch header
- update sequencer to calculate new base fee from previous batch

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*